### PR TITLE
Feature: Admin meta hook for request-aware meta transformations

### DIFF
--- a/packages/core/src/admin-ui/admin-meta-graphql.ts
+++ b/packages/core/src/admin-ui/admin-meta-graphql.ts
@@ -1,5 +1,4 @@
-import type { GraphQLNames, JSONValue } from '../types/utils.ts'
-import type { ListMeta, FieldMeta, FieldGroupMeta } from '../types/index.ts'
+import type { AdminMeta } from '../types/index.ts'
 import { gql } from './apollo.ts'
 
 export const adminMetaQuery = gql`
@@ -139,32 +138,8 @@ export const adminMetaQuery = gql`
   }
 `
 
-// TODO: duplicate, reference core/src/lib/admin-meta.ts
 export type AdminMetaQuery = {
   keystone: {
-    adminMeta: {
-      lists: (ListMeta & {
-        fields: ListMeta['fields'][string][]
-        actions: ListMeta['actions']
-        groups: (FieldGroupMeta & {
-          fields: FieldMeta[]
-        })[]
-        graphql: {
-          names: GraphQLNames
-        }
-
-        pageSize: number
-        initialColumns: string[]
-        initialSearchFields: string[]
-        initialSort: ListMeta['initialSort'] | null
-        initialFilter: JSONValue
-        hiddenFilter: JSONValue | null
-        isSingleton: boolean
-
-        hideNavigation: boolean
-        hideCreate: boolean
-        hideDelete: boolean
-      })[]
-    }
+    adminMeta: AdminMeta
   }
 }

--- a/packages/core/src/lib/admin-meta-graphql.ts
+++ b/packages/core/src/lib/admin-meta-graphql.ts
@@ -1,6 +1,7 @@
 import { QueryMode } from '../types/index.ts'
 import { g } from '../types/schema/index.ts'
 import type { GraphQLNames } from '../types/utils.ts'
+import { resolveAdminMetaForRequest } from './admin-meta.ts'
 import type {
   ActionMetaSource,
   AdminMetaSource,
@@ -366,9 +367,10 @@ const adminMeta = g.object<AdminMetaSource>()({
         itemId: g.arg({ type: g.ID }),
       },
       async resolve(source, { key, itemId }, context) {
+        const list = source.listsByKey?.[key] ?? source.lists.find(list => list.key === key)
         if (itemId === null || itemId === undefined) {
           return {
-            ...source.listsByKey[key],
+            ...list,
             item: null,
           }
         }
@@ -376,12 +378,12 @@ const adminMeta = g.object<AdminMetaSource>()({
         const item = await context.db[key].findOne({ where: { id: itemId } })
         if (!item) {
           return {
-            ...source.listsByKey[key],
+            ...list,
             item: null,
           }
         }
         return {
-          ...source.listsByKey[key],
+          ...list,
           item,
         }
       },
@@ -395,13 +397,21 @@ export const KeystoneMeta = g.object<{ adminMeta: AdminMetaSource }>()({
     adminMeta: g.field({
       type: g.nonNull(adminMeta),
       async resolve({ adminMeta }, _, context) {
-        if (context.__internal.sudo) return adminMeta
+        if (!context.__internal.sudo) {
+          const isAllowed = await adminMeta.isAccessAllowed(context)
+          if (!isAllowed) {
+            // TODO: we need better errors
+            throw new Error('Access denied')
+          }
+        }
 
-        const isAllowed = await adminMeta.isAccessAllowed(context)
-        if (isAllowed) return adminMeta
+        if (!adminMeta.resolveAdminMeta) return adminMeta
 
-        // TODO: we need better errors
-        throw new Error('Access denied')
+        const resolvedAdminMeta = await resolveAdminMetaForRequest(adminMeta, context)
+        return (await adminMeta.resolveAdminMeta({
+          adminMeta: resolvedAdminMeta,
+          context,
+        })) as unknown as AdminMetaSource
       },
     }),
   },

--- a/packages/core/src/lib/admin-meta.ts
+++ b/packages/core/src/lib/admin-meta.ts
@@ -14,7 +14,7 @@ import type {
   MaybePromise,
   MaybeSessionFunction,
 } from '../types/index.ts'
-import type { ActionMeta, FieldMeta, ListMeta } from '../types/admin-meta.ts'
+import type { ActionMeta, AdminMeta, FieldMeta, ListMeta } from '../types/admin-meta.ts'
 import type { GraphQLNames, JSONValue } from '../types/utils.ts'
 import type { InitialisedList } from './core/initialise-lists.ts'
 
@@ -92,11 +92,23 @@ type ListMetaSource_ = {
 }
 export type ListMetaSource = ListMetaSource_ & Omit<ListMeta, keyof ListMetaSource_>
 
+/**
+ * Internal Admin UI metadata assembled from the Keystone configuration.
+ *
+ * This source is shared by requests and may still contain request-dependent resolver functions.
+ * It is converted to a request-local {@link AdminMeta} by
+ * {@link resolveAdminMetaForRequest} before being passed to the public Admin UI metadata hook.
+ */
 export type AdminMetaSource = {
   lists: ListMetaSource[]
   listsByKey: Record<string, ListMetaSource>
   views: string[]
   isAccessAllowed: (context: KeystoneContext) => MaybePromise<boolean>
+  /** Request hook applied to the resolved, request-local Admin UI metadata. */
+  resolveAdminMeta?: (args: {
+    adminMeta: AdminMeta
+    context: KeystoneContext
+  }) => MaybePromise<AdminMeta>
 }
 
 export function createAdminMeta(
@@ -109,6 +121,7 @@ export function createAdminMeta(
     lists: [],
     views: [],
     isAccessAllowed: config.ui?.isAccessAllowed,
+    resolveAdminMeta: config.ui?.hooks?.resolveAdminMeta,
   }
 
   const omittedLists: string[] = []
@@ -396,6 +409,188 @@ export function createAdminMeta(
   return adminMetaRoot
 }
 
+type AdminMetaField = AdminMeta['lists'][number]['fields'][number]
+type AdminMetaAction = AdminMeta['lists'][number]['actions'][number]
+
+/**
+ * Resolves shared Admin UI metadata for a single request.
+ *
+ * Request-dependent metadata functions are evaluated with the supplied Keystone context, and the
+ * returned metadata is rebuilt as a request-local object. This prevents transformations made by
+ * `resolveAdminMeta` from mutating the shared metadata source or leaking into another request.
+ * The hook itself is invoked by the Admin Meta GraphQL resolver after this function returns.
+ */
+export async function resolveAdminMetaForRequest(
+  adminMetaRoot: AdminMetaSource,
+  context: KeystoneContext
+): Promise<AdminMeta> {
+  const resolvedFields = new Map<FieldMetaSource, AdminMetaField>()
+
+  async function resolveField(field: FieldMetaSource): Promise<AdminMetaField> {
+    const existingField = resolvedFields.get(field)
+    if (existingField) return existingField
+
+    const itemArgs = {
+      session: context.session,
+      context,
+      listKey: field.listKey,
+      fieldKey: field.fieldKey,
+      item: null,
+      itemField: null,
+    }
+    const resolvedField = {
+      key: field.key,
+      label: field.label,
+      description: field.description,
+      fieldMeta: cloneAdminMetaValue(field.fieldMeta),
+      viewsIndex: field.viewsIndex,
+      customViewsIndex: field.customViewsIndex,
+      search: field.search,
+      isNonNull: [...field.isNonNull],
+      isFilterable: await resolveAdminMetaValue(field.isFilterable, {}, context),
+      isOrderable: await resolveAdminMetaValue(field.isOrderable, {}, context),
+      createView: {
+        fieldMode: cloneAdminMetaValue(
+          await resolveAdminMetaValue(field.createView.fieldMode, {}, context)
+        ),
+        isRequired: cloneAdminMetaValue(
+          await resolveAdminMetaValue(field.createView.isRequired, {}, context)
+        ),
+      },
+      itemView: {
+        fieldMode: cloneAdminMetaValue(
+          await resolveAdminMetaValue(field.itemView.fieldMode, itemArgs, context)
+        ),
+        fieldPosition: await resolveAdminMetaValue(field.itemView.fieldPosition, itemArgs, context),
+        isRequired: cloneAdminMetaValue(
+          await resolveAdminMetaValue(field.itemView.isRequired, itemArgs, context)
+        ),
+      },
+      listView: {
+        fieldMode: cloneAdminMetaValue(
+          await resolveAdminMetaValue(field.listView.fieldMode, {}, context)
+        ),
+      },
+    } satisfies AdminMetaField
+
+    resolvedFields.set(field, resolvedField)
+    return resolvedField
+  }
+
+  async function resolveAction(action: ActionMetaSource): Promise<AdminMetaAction> {
+    const itemArgs = {
+      session: context.session,
+      context,
+      listKey: action.listKey,
+      actionKey: action.key,
+      item: null,
+    }
+    const actionArguments = []
+
+    for (const argument of action.graphql.arguments) {
+      const source = argument.source
+      let resolvedSource = argument.source
+
+      if (source && 'field' in source) {
+        resolvedSource = {
+          field: await resolveField(source.field),
+        }
+      } else if (source && 'itemField' in source) {
+        resolvedSource = {
+          itemField: source.itemField,
+        }
+      }
+
+      actionArguments.push({
+        name: argument.name,
+        type: argument.type,
+        source: resolvedSource,
+      })
+    }
+
+    return {
+      key: action.key,
+      label: action.label,
+      icon: action.icon,
+      messages: { ...action.messages },
+      graphql: {
+        arguments: actionArguments,
+        names: cloneAdminMetaValue(action.graphql.names),
+      },
+      itemView: {
+        actionMode: cloneAdminMetaValue(
+          await resolveAdminMetaValue(action.itemView.actionMode, itemArgs, context)
+        ),
+        navigation: action.itemView.navigation,
+        hidePrompt: action.itemView.hidePrompt,
+        hideToast: action.itemView.hideToast,
+      },
+      listView: {
+        actionMode: cloneAdminMetaValue(
+          await resolveAdminMetaValue(action.listView.actionMode, {}, context)
+        ),
+      },
+    }
+  }
+
+  const lists: AdminMeta['lists'] = []
+  for (const list of adminMetaRoot.lists) {
+    const fields = []
+    for (const field of list.fields) {
+      fields.push(await resolveField(field))
+    }
+
+    const groups = []
+    for (const group of list.groups) {
+      const groupFields = []
+      for (const field of group.fields) {
+        groupFields.push(await resolveField(field))
+      }
+      groups.push({
+        label: group.label,
+        description: group.description,
+        fields: groupFields,
+      })
+    }
+
+    const actions = []
+    for (const action of list.actions) {
+      actions.push(await resolveAction(action))
+    }
+
+    lists.push({
+      key: list.key,
+      label: list.label,
+      singular: list.singular,
+      plural: list.plural,
+      path: list.path,
+      labelField: list.labelField,
+      fields,
+      groups,
+      actions,
+      graphql: {
+        names: cloneAdminMetaValue(list.graphql.names),
+      },
+      pageSize: list.pageSize,
+      initialColumns: [...list.initialColumns],
+      initialSearchFields: [...list.initialSearchFields],
+      initialSort: cloneAdminMetaValue(list.initialSort),
+      initialFilter: cloneAdminMetaValue(
+        await resolveAdminMetaValue(list.initialFilter, {}, context)
+      ),
+      hiddenFilter: cloneAdminMetaValue(
+        await resolveAdminMetaValue(list.hiddenFilter, {}, context)
+      ),
+      isSingleton: list.isSingleton,
+      hideNavigation: await resolveAdminMetaValue(list.hideNavigation, {}, context),
+      hideCreate: await resolveAdminMetaValue(list.hideCreate, {}, context),
+      hideDelete: await resolveAdminMetaValue(list.hideDelete, {}, context),
+    })
+  }
+
+  return { lists }
+}
+
 let currentAdminMeta: undefined | AdminMetaSource
 
 export function getAdminMetaForRelationshipField() {
@@ -415,6 +610,53 @@ function assertValidView(view: string, location: string) {
       `${location} is an absolute path, which is invalid. You need to use a module path that is resolved from where 'keystone start' is run (see https://github.com/keystonejs/keystone/pull/7805)`
     )
   }
+}
+
+/**
+ * Resolves one static or request-dependent Admin UI metadata value.
+ *
+ * Function values receive the location-specific arguments and the current Keystone context; both
+ * synchronous and asynchronous results are supported. Static values are returned unchanged. This
+ * helper does not clone object results, so callers must apply the appropriate request-local clone
+ * when a resolved value will be exposed to `resolveAdminMeta`.
+ */
+async function resolveAdminMetaValue<Value>(
+  value: Value | ((args: any, context: KeystoneContext) => MaybePromise<Value>),
+  args: any,
+  context: KeystoneContext
+): Promise<Value> {
+  if (typeof value === 'function') {
+    return await (value as (args: any, context: KeystoneContext) => MaybePromise<Value>)(
+      args,
+      context
+    )
+  }
+  return value
+}
+
+/**
+ * Creates a request-local copy of a JSON-like admin metadata value.
+ *
+ * The metadata source is shared across requests, but `resolveAdminMeta` is
+ * allowed to transform the value it receives. Cloning recursively prevents a
+ * hook that mutates a nested object or array from mutating shared metadata or
+ * leaking that mutation into a later request.
+ *
+ * This is intentionally a JSON-tree clone, not a general-purpose deep clone.
+ * Admin metadata should contain JSON-compatible values; values such as
+ * `Date`, `Map`, `Set`, `RegExp`, and class instances are not preserved by
+ * this helper and must be normalised before reaching it.
+ */
+function cloneAdminMetaValue<Value>(value: Value): Value {
+  if (Array.isArray(value)) {
+    return value.map(cloneAdminMetaValue) as Value
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [key, cloneAdminMetaValue(nestedValue)])
+    ) as Value
+  }
+  return value
 }
 
 function normalizeMaybeSessionFunction<

--- a/packages/core/src/types/admin-meta.ts
+++ b/packages/core/src/types/admin-meta.ts
@@ -186,7 +186,7 @@ export type ListMeta = {
   pageSize: number
   initialColumns: string[]
   initialSearchFields: string[]
-  initialSort: ListSortDescriptor<string>
+  initialSort: ListSortDescriptor<string> | null
   initialFilter: JSONValue
   hiddenFilter: JSONValue | null
   isSingleton: boolean
@@ -194,6 +194,44 @@ export type ListMeta = {
   hideNavigation: boolean
   hideCreate: boolean
   hideDelete: boolean
+}
+
+/** Client-facing field metadata with internal views and controllers omitted. */
+type AdminMetaField = Omit<FieldMeta, 'views' | 'controller'>
+
+/** Client-facing field group metadata with its resolved fields. */
+type AdminMetaFieldGroup = Omit<FieldGroupMeta, 'fields'> & {
+  fields: AdminMetaField[]
+}
+
+/** Client-facing action metadata with resolved field argument sources. */
+type AdminMetaAction = Omit<ActionMeta, 'graphql'> & {
+  graphql: Omit<ActionMeta['graphql'], 'arguments'> & {
+    arguments: Array<
+      Omit<ActionMeta['graphql']['arguments'][number], 'source'> & {
+        source: ActionArgumentSourceMeta<AdminMetaField>
+      }
+    >
+  }
+}
+
+/**
+ * Request-resolved Admin UI metadata returned by the `adminMeta` GraphQL field and passed to
+ * `ui.hooks.resolveAdminMeta`.
+ *
+ * This is the client-facing shape: internal list indexes, field views, and field controllers are
+ * omitted. Values that are configured as request-dependent functions have already been resolved
+ * when this type is passed to the hook.
+ */
+export type AdminMeta = {
+  lists: Array<
+    Omit<ListMeta, 'fields' | 'groups' | 'actions' | 'initialSort'> & {
+      fields: AdminMetaField[]
+      groups: AdminMetaFieldGroup[]
+      actions: AdminMetaAction[]
+      initialSort: ListMeta['initialSort']
+    }
+  >
 }
 
 export type Item = {

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -8,6 +8,7 @@ import type express from 'express'
 import type { GraphQLSchema } from 'graphql/index.js'
 
 import type { BaseKeystoneTypeInfo, DatabaseProvider, KeystoneContext } from '../index.ts'
+import type { AdminMeta } from '../admin-meta.ts'
 import type { SessionStrategy } from '../session.ts'
 import type { MaybePromise } from '../utils.ts'
 import type { FieldAccessControl, ListAccessControl } from './access-control.ts'
@@ -27,6 +28,25 @@ export type * from './lists.ts'
 
 export type ListDefaults = {
   graphql?: Pick<ListGraphQLConfig<any>, 'omit' | 'maxTake'>
+}
+
+/** Hooks for customizing the Admin UI metadata exposed through GraphQL. */
+export type AdminUIHooks<TypeInfo extends BaseKeystoneTypeInfo> = {
+  /**
+   * Runs when the `adminMeta` GraphQL field is resolved for an allowed request, after request-
+   * dependent metadata values have been resolved and before the metadata is returned to the
+   * client. It is not called for ordinary data GraphQL operations. If `adminMeta` is resolved more
+   * than once in a request, the hook may also run more than once.
+   *
+   * Use this for localization, tenant-specific presentation metadata, or other request-aware
+   * customization. The metadata passed to the hook is request-local and may be transformed, but
+   * stable structural identifiers should be preserved. `context.req` may be absent when the hook
+   * runs outside an HTTP request context.
+   */
+  resolveAdminMeta?: (args: {
+    adminMeta: AdminMeta
+    context: KeystoneContext<TypeInfo>
+  }) => MaybePromise<AdminMeta>
 }
 
 export type KeystoneConfigPre<TypeInfo extends BaseKeystoneTypeInfo = BaseKeystoneTypeInfo> = {
@@ -148,6 +168,8 @@ export type KeystoneConfigPre<TypeInfo extends BaseKeystoneTypeInfo = BaseKeysto
   telemetry?: boolean
 
   ui?: {
+    hooks?: AdminUIHooks<TypeInfo>
+
     /** Completely disables the Admin UI */
     isDisabled?: boolean
 
@@ -191,7 +213,9 @@ export type KeystoneConfig<TypeInfo extends BaseKeystoneTypeInfo = BaseKeystoneT
   }
   session: KeystoneConfigPre<TypeInfo>['session']
   telemetry: boolean
-  ui: NonNullable<Required<KeystoneConfigPre<TypeInfo>['ui']>>
+  ui: Omit<NonNullable<Required<KeystoneConfigPre<TypeInfo>['ui']>>, 'hooks'> & {
+    hooks?: AdminUIHooks<TypeInfo>
+  }
 }
 
 export type { BaseFields, ListConfig, MaybeItemFunctionWithFilter, MaybeSessionFunction }

--- a/tests/api-tests/admin-meta.test.ts
+++ b/tests/api-tests/admin-meta.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from 'vitest'
+import { IncomingMessage } from 'node:http'
+import { Socket } from 'node:net'
 import { group, list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
-import { integer, text } from '@keystone-6/core/fields'
+import { integer, select, text } from '@keystone-6/core/fields'
 import { setupTestRunner } from '@keystone-6/api-tests/test-runner'
 import { adminMetaQuery } from '../../packages/core/src/admin-ui/admin-meta-graphql.ts'
 import { dbProvider } from './utils.ts'
@@ -485,6 +487,386 @@ test(
           },
         },
       },
+    })
+  })
+)
+
+let resolveAdminMetaCalls = 0
+let expectedResolveAdminMetaContext: object | undefined
+
+const hookRunner = setupTestRunner({
+  config: {
+    ui: {
+      hooks: {
+        resolveAdminMeta: ({ adminMeta, context }) => {
+          resolveAdminMetaCalls++
+          if (expectedResolveAdminMetaContext) {
+            expect(context).toBe(expectedResolveAdminMetaContext)
+          }
+
+          const locale = (context.session as { locale?: string } | undefined)?.locale
+          if (locale === 'error') throw new Error('resolveAdminMeta failed')
+          if (locale === 'mutate') {
+            adminMeta.lists[0].label = 'Mutated Articles'
+            return adminMeta
+          }
+
+          const headerLabel = context.req?.headers['x-admin-meta-label']
+          if (headerLabel) {
+            adminMeta.lists[0].label = Array.isArray(headerLabel) ? headerLabel[0] : headerLabel
+          } else if (locale === 'de') {
+            expect('listsByKey' in adminMeta).toBe(false)
+            expect('isAccessAllowed' in adminMeta).toBe(false)
+            expect(typeof adminMeta.lists[0].hideNavigation).toBe('boolean')
+            expect(typeof adminMeta.lists[0].fields[0].isFilterable).toBe('boolean')
+            adminMeta.lists[0].label = 'Artikel'
+          } else if (locale === 'async') {
+            return Promise.resolve({
+              ...adminMeta,
+              lists: adminMeta.lists.map(list => ({ ...list, label: 'Async Articles' })),
+            })
+          }
+
+          return adminMeta
+        },
+      },
+    },
+    lists: {
+      Article: list({
+        access: allowAll,
+        fields: { title: text() },
+        ui: {
+          label: 'Articles',
+          hideNavigation: ({ session }) =>
+            (session as { locale?: string } | undefined)?.locale === 'de',
+        },
+      }),
+    },
+  },
+})
+
+const hookQuery = gql`
+  query {
+    keystone {
+      adminMeta {
+        lists {
+          key
+          label
+          hideNavigation
+        }
+      }
+    }
+  }
+`
+
+test(
+  'resolveAdminMeta supports synchronous hooks and receives resolved request context',
+  hookRunner(async ({ context }) => {
+    resolveAdminMetaCalls = 0
+    const requestContext = context.withSession({ locale: 'de' })
+    const queryContext = requestContext.sudo()
+    expectedResolveAdminMetaContext = queryContext
+
+    const data = (await queryContext.graphql.run({ query: hookQuery })) as any
+
+    expect(data.keystone.adminMeta.lists).toEqual([
+      { key: 'Article', label: 'Artikel', hideNavigation: true },
+    ])
+    expect(resolveAdminMetaCalls).toBe(1)
+    expectedResolveAdminMetaContext = undefined
+  })
+)
+
+test(
+  'resolveAdminMeta awaits asynchronous hooks',
+  hookRunner(async ({ context }) => {
+    resolveAdminMetaCalls = 0
+    const queryContext = context.withSession({ locale: 'async' }).sudo()
+    expectedResolveAdminMetaContext = queryContext
+
+    const data = (await queryContext.graphql.run({ query: hookQuery })) as any
+
+    expect(data.keystone.adminMeta.lists[0].label).toBe('Async Articles')
+    expect(resolveAdminMetaCalls).toBe(1)
+    expectedResolveAdminMetaContext = undefined
+  })
+)
+
+test(
+  'resolveAdminMeta can read request headers',
+  hookRunner(async ({ context }) => {
+    resolveAdminMetaCalls = 0
+    const req = new IncomingMessage(new Socket())
+    req.headers['x-admin-meta-label'] = 'Header Articles'
+    const queryContext = (await context.withRequest(req)).sudo()
+    expectedResolveAdminMetaContext = queryContext
+
+    const data = (await queryContext.graphql.run({ query: hookQuery })) as any
+
+    expect(data.keystone.adminMeta.lists[0].label).toBe('Header Articles')
+    expect(resolveAdminMetaCalls).toBe(1)
+    expectedResolveAdminMetaContext = undefined
+  })
+)
+
+test(
+  'resolveAdminMeta does not share transformed metadata between requests',
+  hookRunner(async ({ context }) => {
+    resolveAdminMetaCalls = 0
+    const first = (await context.withSession({ locale: 'mutate' }).sudo().graphql.run({
+      query: hookQuery,
+    })) as any
+    const second = (await context.withSession({ locale: 'en' }).sudo().graphql.run({
+      query: hookQuery,
+    })) as any
+
+    expect(first.keystone.adminMeta.lists[0].label).toBe('Mutated Articles')
+    expect(second.keystone.adminMeta.lists[0].label).toBe('Articles')
+    expect(resolveAdminMetaCalls).toBe(2)
+  })
+)
+
+test(
+  'resolveAdminMeta errors follow the GraphQL error path',
+  hookRunner(async ({ context }) => {
+    const result = await context.withSession({ locale: 'error' }).sudo().graphql.raw({
+      query: hookQuery,
+    })
+
+    expect(result.data).toBeNull()
+    expect(result.errors?.[0]?.message).toBe('resolveAdminMeta failed')
+  })
+)
+
+let cloneAdminMetaRequest = 0
+
+const cloneAdminMetaRunner = setupTestRunner({
+  config: {
+    ui: {
+      hooks: {
+        resolveAdminMeta: ({ adminMeta }) => {
+          cloneAdminMetaRequest++
+          if (cloneAdminMetaRequest === 1) {
+            const article = adminMeta.lists[0]
+            const title = article.fields.find(field => field.key === 'title')!
+            const category = article.fields.find(field => field.key === 'category')!
+
+            const titleFieldMeta = title.fieldMeta as any
+            titleFieldMeta.validation.length.min = 7
+
+            const categoryFieldMeta = category.fieldMeta as any
+            categoryFieldMeta.options[0].label = 'Mutated option'
+
+            const initialFilter = article.initialFilter as any
+            initialFilter.title.contains = 'mutated'
+
+            const initialSort = article.initialSort as any
+            initialSort.field = 'id'
+
+            const graphqlNames = article.graphql.names as any
+            graphqlNames.outputTypeName = 'MutatedArticle'
+          }
+
+          return adminMeta
+        },
+      },
+    },
+    lists: {
+      Article: list({
+        access: allowAll,
+        fields: {
+          title: text(),
+          category: select({ options: ['one', 'two'] }),
+        },
+        ui: {
+          listView: {
+            initialFilter: { title: { contains: 'original' } },
+            initialSort: { field: 'title', direction: 'ASC' },
+          },
+        },
+      }),
+    },
+  },
+})
+
+test(
+  'cloneAdminMetaValue clones nested metadata values per request',
+  cloneAdminMetaRunner(async ({ context }) => {
+    cloneAdminMetaRequest = 0
+
+    const first = (await context.sudo().graphql.run({
+      query: gql`
+        query {
+          keystone {
+            adminMeta {
+              lists {
+                fields {
+                  key
+                  fieldMeta
+                }
+                graphql {
+                  names {
+                    outputTypeName
+                  }
+                }
+                initialFilter
+                initialSort {
+                  field
+                  direction
+                }
+              }
+            }
+          }
+        }
+      `,
+    })) as any
+
+    const second = (await context.sudo().graphql.run({
+      query: gql`
+        query {
+          keystone {
+            adminMeta {
+              lists {
+                fields {
+                  key
+                  fieldMeta
+                }
+                graphql {
+                  names {
+                    outputTypeName
+                  }
+                }
+                initialFilter
+                initialSort {
+                  field
+                  direction
+                }
+              }
+            }
+          }
+        }
+      `,
+    })) as any
+
+    const firstArticle = first.keystone.adminMeta.lists[0]
+    const secondArticle = second.keystone.adminMeta.lists[0]
+    const firstTitle = firstArticle.fields.find((field: any) => field.key === 'title')
+    const secondTitle = secondArticle.fields.find((field: any) => field.key === 'title')
+    const firstCategory = firstArticle.fields.find((field: any) => field.key === 'category')
+    const secondCategory = secondArticle.fields.find((field: any) => field.key === 'category')
+
+    expect(firstTitle.fieldMeta.validation.length.min).toBe(7)
+    expect(firstCategory.fieldMeta.options[0].label).toBe('Mutated option')
+    expect(firstArticle.initialFilter.title.contains).toBe('mutated')
+    expect(firstArticle.initialSort).toEqual({ field: 'id', direction: 'ASC' })
+    expect(firstArticle.graphql.names.outputTypeName).toBe('MutatedArticle')
+
+    expect(secondTitle.fieldMeta.validation.length.min).toBeNull()
+    expect(secondCategory.fieldMeta.options[0]).toEqual({ label: 'One', value: 'one' })
+    expect(secondArticle.initialFilter).toEqual({ title: { contains: 'original' } })
+    expect(secondArticle.initialSort).toEqual({ field: 'title', direction: 'ASC' })
+    expect(secondArticle.graphql.names.outputTypeName).toBe('Article')
+    expect(cloneAdminMetaRequest).toBe(2)
+  })
+)
+
+const resolveAdminMetaRunner = setupTestRunner({
+  config: {
+    ui: {
+      hooks: {
+        resolveAdminMeta: ({ adminMeta }) => adminMeta,
+      },
+    },
+    lists: {
+      Article: list({
+        access: allowAll,
+        fields: {
+          title: text({
+            ui: {
+              createView: {
+                fieldMode: async () => 'hidden',
+                isRequired: async () => true,
+              },
+              itemView: {
+                fieldMode: async () => 'read',
+                fieldPosition: async () => 'sidebar',
+                isRequired: async () => true,
+              },
+              listView: {
+                fieldMode: async () => 'hidden',
+              },
+            },
+          }),
+        },
+        ui: {
+          hideNavigation: async () => true,
+          hideCreate: async () => false,
+          hideDelete: async () => true,
+          listView: {
+            initialFilter: async () => ({ title: { contains: 'async' } }),
+            hiddenFilter: async () => ({ title: { contains: 'hidden' } }),
+          },
+        },
+      }),
+    },
+  },
+})
+
+test(
+  'resolveAdminMetaValue resolves static and asynchronous metadata values',
+  resolveAdminMetaRunner(async ({ context }) => {
+    const data = (await context.sudo().graphql.run({
+      query: gql`
+        query {
+          keystone {
+            adminMeta {
+              lists {
+                fields {
+                  key
+                  createView {
+                    fieldMode
+                    isRequired
+                  }
+                  itemView {
+                    fieldMode
+                    fieldPosition
+                    isRequired
+                  }
+                  listView {
+                    fieldMode
+                  }
+                }
+                initialFilter
+                hiddenFilter
+                hideNavigation
+                hideCreate
+                hideDelete
+              }
+            }
+          }
+        }
+      `,
+    })) as any
+
+    const article = data.keystone.adminMeta.lists[0]
+    const title = article.fields.find((field: any) => field.key === 'title')
+    const id = article.fields.find((field: any) => field.key === 'id')
+
+    expect(article.initialFilter).toEqual({ title: { contains: 'async' } })
+    expect(article.hiddenFilter).toEqual({ title: { contains: 'hidden' } })
+    expect(article.hideNavigation).toBe(true)
+    expect(article.hideCreate).toBe(false)
+    expect(article.hideDelete).toBe(true)
+
+    expect(title).toMatchObject({
+      createView: { fieldMode: 'hidden', isRequired: true },
+      itemView: { fieldMode: 'read', fieldPosition: 'sidebar', isRequired: true },
+      listView: { fieldMode: 'hidden' },
+    })
+    expect(id).toMatchObject({
+      createView: { fieldMode: 'hidden', isRequired: false },
+      itemView: { fieldMode: 'edit', fieldPosition: 'sidebar', isRequired: false },
+      listView: { fieldMode: 'read' },
     })
   })
 )

--- a/tests/api-tests/admin-meta.test.ts
+++ b/tests/api-tests/admin-meta.test.ts
@@ -784,16 +784,16 @@ const resolveAdminMetaRunner = setupTestRunner({
           title: text({
             ui: {
               createView: {
-                fieldMode: async () => 'hidden',
+                fieldMode: async () => 'hidden' as const,
                 isRequired: async () => true,
               },
               itemView: {
-                fieldMode: async () => 'read',
-                fieldPosition: async () => 'sidebar',
+                fieldMode: async () => 'read' as const,
+                fieldPosition: async () => 'sidebar' as const,
                 isRequired: async () => true,
               },
               listView: {
-                fieldMode: async () => 'hidden',
+                fieldMode: async () => 'hidden' as const,
               },
             },
           }),


### PR DESCRIPTION
## Summary
This PR adds the optional ui.hooks.resolveAdminMeta API, enabling request-aware Admin UI metadata transformations such as localization, tenant-specific labels, or branding.

## Functionality
When configured, the hook runs in the adminMeta root resolver after access checks and request-dependent metadata values have been resolved. It receives the full KeystoneContext and a request-local, serializable AdminMeta, supports synchronous and asynchronous returns, and does not expose internal AdminMetaSource fields. It is not invoked for ordinary data GraphQL operations.

## Disclaimer
Without the hook, the existing resolver path, access-control order, GraphQL schema, and Admin UI queries remain unchanged. Request-local metadata reconstruction prevents hook mutations from leaking between requests. Tests cover synchronous and asynchronous hooks, context and headers, session-specific results, invocation behavior, isolation, and error propagation.