### PR TITLE
Replace Node `req` and `res` on context with WHATWG Headers

### DIFF
--- a/.changeset/empty-months-fetch.md
+++ b/.changeset/empty-months-fetch.md
@@ -1,0 +1,6 @@
+---
+'@keystone-6/auth': major
+'@keystone-6/core': major
+---
+
+Replaces Node.js HTTP `context.req` and `context.res` on `KeystoneContext` with WHATWG `Headers` on `context.req` and `context.res`. Use `context.withHeaders(req, res?)` to create a request-bound context.

--- a/docs/content/docs/context/overview.md
+++ b/docs/content/docs/context/overview.md
@@ -1,5 +1,5 @@
 ---
-title: "Context Overview"
+title: 'Context Overview'
 description: "The Context object is the primary API entry point for all of the run-time functionality of your system. It's APIs can be used to write things like access control, hooks, testing and GraphQL schema extensions."
 ---
 
@@ -20,7 +20,7 @@ const context = {
   // Database API
   db,
 
-  // HTTP request object
+  // HTTP headers
   req,
   res,
 
@@ -38,7 +38,7 @@ const context = {
   // New context creators
   sudo,
   internal,
-  withRequest,
+  withHeaders,
   withSession,
 
   // Transactions
@@ -49,10 +49,11 @@ const context = {
 }
 ```
 
-### HTTP request object
+### HTTP headers
 
-`req`: The [IncomingMessage](https://nodejs.org/api/http.html#class-httpincomingmessage) object from the HTTP request.
-`res`: The [ServerResponse](https://nodejs.org/api/http.html#class-httpserverresponse) object for the HTTP request.
+`req`: A WHATWG [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) object containing the incoming request headers.
+
+`res`: A WHATWG `Headers` object for outgoing response headers. It can be undefined for read-only contexts.
 
 ### Query API
 
@@ -88,7 +89,7 @@ See the [session API](../config/session#session-context) for more details.
 
 `session`: The current session data object.
 
-`sessionStrategy`: an object containing functions(`get`, `start` and `end`) that manipulate a session. See the [session API](../config/session#session-context) for more details.
+`sessionStrategy`: an object containing functions (`get`, `start` and `end`) that manipulate a session. See the [session API](../config/session#session-context) for more details.
 
 ### New context creators
 
@@ -99,7 +100,7 @@ The following functions will create a new `Context` object with this behaviour m
 
 `internal()`: A function which returns a new `Context` object that bypasses `graphql.omit` on lists and fields, allowing you to query and mutate data that is otherwise omitted from the GraphQL API.
 
-`withRequest(req, res)`: A function which returns a new `Context` object with the `.session` determined by your `sessionStrategy.get` function.
+`withHeaders(req, res?)`: Creates a context from WHATWG `Headers`. Request headers are cloned.
 
 `withSession(newSession)`: A function which returns a new `Context` object with the `.session` object replaced by the `newSession` argument.
 

--- a/examples/actions/schema.ts
+++ b/examples/actions/schema.ts
@@ -60,7 +60,7 @@ export const lists = {
     actions: {
       vote: action({
         access: ({ context }) => {
-          const ua = context.req?.headers['user-agent'] ?? ''
+          const ua = context.req?.get('user-agent') ?? ''
           // only allow voting from Chrome browsers
           return ua.includes('Chrome')
         },

--- a/examples/custom-session-jwt/keystone.ts
+++ b/examples/custom-session-jwt/keystone.ts
@@ -40,7 +40,7 @@ const jwtSessionStrategy = {
   async get({ context }: { context: Context }): Promise<Session | undefined> {
     if (!context.req) return
 
-    const { cookie = '' } = context.req.headers
+    const cookie = context.req.get('cookie') ?? ''
     const [cookieName, jwt] = cookie.split('=')
     if (cookieName !== 'user') return
 

--- a/examples/custom-session-next-auth/session.ts
+++ b/examples/custom-session-next-auth/session.ts
@@ -1,5 +1,4 @@
-import { getServerSession } from 'next-auth/next'
-import type { DefaultJWT } from 'next-auth/jwt'
+import { getToken, type DefaultJWT } from 'next-auth/jwt'
 import type { DefaultSession } from 'next-auth'
 import GithubProvider from 'next-auth/providers/github'
 import type { Context } from './generated/keystone/types'
@@ -48,25 +47,12 @@ declare module './generated/keystone/types' {
 
 export const nextAuthSessionStrategy = {
   async get({ context }: { context: Context }) {
-    const { req, res } = context
-    const { headers } = req ?? {}
-    if (!headers?.cookie || !res) return
-
-    // next-auth needs a different cookies structure
-    const cookies: Record<string, string> = {}
-    for (const part of headers.cookie.split(';')) {
-      const [key, value] = part.trim().split('=')
-      cookies[key] = decodeURIComponent(value)
-    }
-
-    const nextAuthSession = await getServerSession(
-      { headers, cookies } as any,
-      res,
-      nextAuthOptions
-    )
-    if (!nextAuthSession) return
-
-    const { authId } = nextAuthSession.keystone
+    if (!context.req) return
+    const token = await getToken({
+      req: { headers: Object.fromEntries(context.req) } as any,
+      secret: sessionSecret,
+    })
+    const authId = token?.sub
     if (!authId) return
 
     const author = await context.sudo().db.Author.findOne({

--- a/examples/custom-session-passport/auth.ts
+++ b/examples/custom-session-passport/auth.ts
@@ -59,13 +59,22 @@ export function passportMiddleware(commonContext: KeystoneContext<TypeInfo>): Ro
       return
     }
 
-    const context = await commonContext.withRequest(req, res)
+    const responseHeaders = new Headers()
+    const context = await commonContext.withHeaders(
+      new Headers(
+        Object.entries(req.headers).flatMap(([key, value]): [string, string][] =>
+          value ? (Array.isArray(value) ? value.map(inner => [key, inner]) : [[key, value]]) : []
+        )
+      ),
+      responseHeaders
+    )
 
     // starts the session, and sets the cookie on context.res
     await context.sessionStrategy?.start({
       context,
       data: req.user,
     })
+    for (const value of responseHeaders.getSetCookie()) res.appendHeader('Set-Cookie', value)
 
     res.redirect('/auth/session')
   })
@@ -73,8 +82,13 @@ export function passportMiddleware(commonContext: KeystoneContext<TypeInfo>): Ro
   // show the current session object
   //   WARNING: this is for demonstration purposes only, probably dont do this
   router.get('/auth/session', async (req, res) => {
-    const context = await commonContext.withRequest(req, res)
-
+    const context = await commonContext.withHeaders(
+      new Headers(
+        Object.entries(req.headers).flatMap(([key, value]): [string, string][] =>
+          value ? (Array.isArray(value) ? value.map(inner => [key, inner]) : [[key, value]]) : []
+        )
+      )
+    )
     res.setHeader('Content-Type', 'application/json')
     res.send(JSON.stringify(context.session))
     res.end()

--- a/examples/custom-session/keystone.ts
+++ b/examples/custom-session/keystone.ts
@@ -12,7 +12,7 @@ const sillySessionStrategy = {
     //   use `Cookie:user=clh9v762w0002sbhmhhyc0340` for Bob
     //
     // in practice, you should use authentication for your sessions, such as OAuth or JWT
-    const { cookie = '' } = context.req.headers
+    const cookie = context.req.get('cookie') ?? ''
     const [cookieName, id] = cookie.split('=')
     if (cookieName !== 'user') return
 

--- a/examples/extend-express-app/keystone.ts
+++ b/examples/extend-express-app/keystone.ts
@@ -28,7 +28,17 @@ export default config<TypeInfo>({
       //   http://localhost:3000/rest/posts?draft=1
       //
       app.get('/rest/posts', async (req, res) => {
-        const context = await commonContext.withRequest(req, res)
+        const context = await commonContext.withHeaders(
+          new Headers(
+            Object.entries(req.headers).flatMap(([key, value]): [string, string][] =>
+              value
+                ? Array.isArray(value)
+                  ? value.map(inner => [key, inner])
+                  : [[key, value]]
+                : []
+            )
+          )
+        )
         // if (!context.session) return res.status(401).end()
 
         const isDraft = req.query?.draft === '1'
@@ -58,7 +68,17 @@ export default config<TypeInfo>({
 
         // this example HTTP GET handler retrieves a post in the database for your context
         //   returning it as JSON
-        const context = await commonContext.withRequest(req, res)
+        const context = await commonContext.withHeaders(
+          new Headers(
+            Object.entries(req.headers).flatMap(([key, value]): [string, string][] =>
+              value
+                ? Array.isArray(value)
+                  ? value.map(inner => [key, inner])
+                  : [[key, value]]
+                : []
+            )
+          )
+        )
         // if (!context.session) return res.status(401).end()
 
         const task = await context.query.Post.findOne({

--- a/examples/extend-graphql-subscriptions/websocket.ts
+++ b/examples/extend-graphql-subscriptions/websocket.ts
@@ -29,7 +29,18 @@ export function extendHttpServer(httpServer: http.Server, commonContext: Context
       schema: commonContext.graphql.schema,
       // run these onSubscribe functions as needed or remove them if you don't need them
       onSubscribe: async (ctx: any, msg) => {
-        const context = await commonContext.withRequest(ctx.extra.request)
+        const context = await commonContext.withHeaders(
+          new Headers(
+            Object.entries(ctx.extra.request.headers as http.IncomingHttpHeaders).flatMap(
+              ([key, value]): [string, string][] =>
+                value
+                  ? Array.isArray(value)
+                    ? value.map(inner => [key, inner])
+                    : [[key, value]]
+                  : []
+            )
+          )
+        )
         // Return the execution args for this subscription passing through the Keystone Context
         return {
           schema: commonContext.graphql.schema,

--- a/examples/framework-nextjs-pages-directory/src/pages/api/graphql.ts
+++ b/examples/framework-nextjs-pages-directory/src/pages/api/graphql.ts
@@ -17,9 +17,31 @@ export default createYoga<{
   /*
     `keystoneContext` object doesn't have user's session information.
     You need an authenticated context to CRUD data behind access control.
-    keystoneContext.withRequest(req, res) automatically unwraps the session cookie
+    keystoneContext.withHeaders(request.headers, responseHeaders) automatically unwraps the session cookie
     in the request object and gives you a `context` object with session info
     and an elevated sudo context to bypass access control if needed (context.sudo()).
   */
-  context: ({ req, res }) => keystoneContext.withRequest(req, res),
+  context: ({ request }) => {
+    const responseHeaders = new Headers()
+    requestToResponseHeaders.set(request, responseHeaders)
+    return keystoneContext.withHeaders(request.headers, responseHeaders)
+  },
+  plugins: [
+    {
+      onResponse({ response, request }) {
+        const headers = requestToResponseHeaders.get(request)
+        if (headers) {
+          for (const [key, value] of headers.entries()) {
+            if (key !== 'set-cookie') response.headers.set(key, value)
+          }
+          for (const value of headers.getSetCookie()) {
+            response.headers.append('set-cookie', value)
+          }
+        }
+      },
+    },
+  ],
+  fetchAPI: globalThis,
 })
+
+const requestToResponseHeaders = new WeakMap<Request, Headers>()

--- a/examples/framework-nextjs-pages-directory/src/pages/index.tsx
+++ b/examples/framework-nextjs-pages-directory/src/pages/index.tsx
@@ -63,8 +63,14 @@ const Home: NextPage = ({ users }: InferGetServerSidePropsType<typeof getServerS
   )
 }
 
-export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
-  const context = await keystoneContext.withRequest(req, res)
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const context = await keystoneContext.withHeaders(
+    new Headers(
+      Object.entries(req.headers).flatMap(([key, value]): [string, string][] =>
+        value ? (Array.isArray(value) ? value.map(inner => [key, inner]) : [[key, value]]) : []
+      )
+    )
+  )
   const users = await context.query.User.findMany({
     query: 'id name about',
   })

--- a/examples/hooks/keystone.ts
+++ b/examples/hooks/keystone.ts
@@ -13,4 +13,12 @@ export default config<TypeInfo>({
     }),
   },
   lists,
+  server: {
+    extendExpressApp(app) {
+      app.use((req, _res, next) => {
+        req.headers['x-forwarded-for'] = req.socket.remoteAddress
+        next()
+      })
+    },
+  },
 })

--- a/examples/hooks/schema.ts
+++ b/examples/hooks/schema.ts
@@ -104,12 +104,12 @@ export const lists = {
       resolveInput: {
         create: ({ context, resolvedData }) => {
           //resolvedData.createdAt = new Date(); // see createdAt field hook
-          resolvedData.createdBy = `${context.req?.socket.remoteAddress} (${context.req?.headers['user-agent']})`
+          resolvedData.createdBy = `${context.req?.get('x-forwarded-for')} (${context.req?.get('user-agent')})`
           return resolvedData
         },
         update: ({ context, resolvedData }) => {
           //resolvedData.updatedAt = new Date(); // see updatedAt field hook
-          resolvedData.updatedBy = `${context.req?.socket.remoteAddress} (${context.req?.headers['user-agent']})`
+          resolvedData.updatedBy = `${context.req?.get('x-forwarded-for')} (${context.req?.get('user-agent')})`
           return resolvedData
         },
       },

--- a/examples/logging/keystone.ts
+++ b/examples/logging/keystone.ts
@@ -28,6 +28,10 @@ export default config<TypeInfo>({
   server: {
     extendExpressApp(app) {
       app.use(pino)
+      app.use((req, _res, next) => {
+        if (req.id !== undefined) req.headers['x-request-id'] = String(req.id)
+        next()
+      })
     },
   },
   graphql: {
@@ -46,7 +50,7 @@ export default config<TypeInfo>({
                 pino.logger.info(
                   {
                     req: requestContext.contextValue.req
-                      ? { id: requestContext.contextValue.req?.id }
+                      ? { id: requestContext.contextValue.req?.get('x-request-id') }
                       : undefined,
                     responseTime: Date.now() - start,
                     graphql: {

--- a/examples/reuse/keystone.ts
+++ b/examples/reuse/keystone.ts
@@ -13,4 +13,12 @@ export default config({
     // WARNING: this is only needed for our monorepo examples, don't do this
   },
   lists,
+  server: {
+    extendExpressApp(app) {
+      app.use((req, _res, next) => {
+        req.headers['x-forwarded-for'] = req.socket.remoteAddress
+        next()
+      })
+    },
+  },
 })

--- a/examples/reuse/schema.ts
+++ b/examples/reuse/schema.ts
@@ -47,7 +47,7 @@ function trackingFields<ListTypeInfo extends CompatibleLists>() {
       hooks: {
         resolveInput: {
           async create({ context }) {
-            return `${context.req?.socket.remoteAddress} (${context.req?.headers['user-agent']})`
+            return `${context.req?.get('x-forwarded-for')} (${context.req?.get('user-agent')})`
           },
           async update() {
             return undefined
@@ -77,7 +77,7 @@ function trackingFields<ListTypeInfo extends CompatibleLists>() {
 
           // TODO: refined types for the return types
           //   FIXME: CommonFieldConfig need not always be generalised
-          return `${context.req?.socket.remoteAddress} (${context.req?.headers['user-agent']})`
+          return `${context.req?.get('x-forwarded-for')} (${context.req?.get('user-agent')})`
         },
       },
     }),

--- a/examples/usecase-blog-moderated/keystone.ts
+++ b/examples/usecase-blog-moderated/keystone.ts
@@ -13,7 +13,7 @@ const sillySessionStrategy = {
     //   use `Cookie:user=clh9v7ahs0004sbhmpx30w85n` for Eve (contributor)
     //
     // in practice, you should use authentication for your sessions, such as OAuth or JWT
-    const { cookie = '' } = context.req.headers
+    const cookie = context.req.get('cookie') ?? ''
     const [cookieName, id] = cookie.split('=')
     if (cookieName !== 'user') return
 

--- a/packages/core/src/lib/context/createContext.ts
+++ b/packages/core/src/lib/context/createContext.ts
@@ -1,4 +1,3 @@
-import type { IncomingMessage, ServerResponse } from 'http'
 import { type ExecutionResult, type GraphQLSchema, graphql, print } from 'graphql/index.js'
 import type { KeystoneContext, KeystoneGraphQLAPI, KeystoneConfig } from '../../types/index.ts'
 
@@ -53,8 +52,8 @@ export function createContext({
     sudo,
   }: {
     prisma: any
-    req?: IncomingMessage
-    res?: ServerResponse
+    req?: Headers
+    res?: Headers
     session?: unknown
     internal: boolean
     sudo: boolean
@@ -102,10 +101,10 @@ export function createContext({
       sessionStrategy: config.session,
       ...(session ? { session } : {}),
 
-      withRequest: async (newReq, newRes) => {
+      withHeaders: async (newReq, newRes) => {
         const newContext = construct({
           prisma,
-          req: newReq,
+          req: new Headers(newReq),
           res: newRes,
           session,
           internal,

--- a/packages/core/src/lib/context/node-headers.ts
+++ b/packages/core/src/lib/context/node-headers.ts
@@ -1,0 +1,18 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+
+export function headersFromRequest(req: IncomingMessage) {
+  return new Headers(
+    Object.entries(req.headers).flatMap(([key, value]): [string, string][] =>
+      value ? (Array.isArray(value) ? value.map(inner => [key, inner]) : [[key, value]]) : []
+    )
+  )
+}
+
+export function addHeadersToResponse(headers: Headers, res: ServerResponse) {
+  for (const [name, value] of headers) {
+    if (name !== 'set-cookie') res.setHeader(name, value)
+  }
+
+  const cookies = headers.getSetCookie()
+  if (cookies.length) res.setHeader('set-cookie', cookies)
+}

--- a/packages/core/src/lib/express.ts
+++ b/packages/core/src/lib/express.ts
@@ -4,12 +4,13 @@ import { json } from 'body-parser'
 import { expressMiddleware } from '@as-integrations/express5'
 import express from 'express'
 import { GraphQLError, type GraphQLFormattedError } from 'graphql/index.js'
-import { type ApolloServerOptions, ApolloServer } from '@apollo/server'
+import { type ApolloServerOptions, type ApolloServerPlugin, ApolloServer } from '@apollo/server'
 import { ApolloServerPluginLandingPageDisabled } from '@apollo/server/plugin/disabled'
 import { ApolloServerPluginLandingPageLocalDefault } from '@apollo/server/plugin/landingPage/default'
 // @ts-expect-error
 import graphqlUploadExpress from 'graphql-upload/graphqlUploadExpress.js'
 import type { KeystoneContext, KeystoneConfig } from '../types/index.ts'
+import { addHeadersToResponse, headersFromRequest } from './context/node-headers.ts'
 
 /*
 NOTE: This creates the main Keystone express server, including the
@@ -69,20 +70,36 @@ export async function createExpressServer(
   await config.server.extendHttpServer(httpServer, context)
 
   const apolloConfig = config.graphql.apolloConfig
+  const responses = new WeakMap<Headers, express.Response>()
+  const responseHeadersPlugin: ApolloServerPlugin<KeystoneContext> = {
+    async requestDidStart() {
+      return {
+        async willSendResponse({ contextValue }) {
+          if (contextValue.res) {
+            const response = responses.get(contextValue.res)
+            responses.delete(contextValue.res)
+            if (response) addHeadersToResponse(contextValue.res, response)
+          }
+        },
+      }
+    },
+  }
   const serverConfig = {
     includeStacktraceInErrorResponses: config.graphql.debug,
     ...apolloConfig,
     formatError: formatError(config.graphql),
     schema: context.graphql.schema,
-    plugins:
-      config.graphql.playground === 'apollo'
-        ? apolloConfig?.plugins
+    plugins: [
+      ...(config.graphql.playground === 'apollo'
+        ? (apolloConfig?.plugins ?? [])
         : [
             config.graphql.playground
               ? ApolloServerPluginLandingPageLocalDefault()
               : ApolloServerPluginLandingPageDisabled(),
             ...(apolloConfig?.plugins ?? []),
-          ],
+          ]),
+      responseHeadersPlugin,
+    ],
   } as ApolloServerOptions<KeystoneContext> // TODO: satisfies
 
   const apolloServer = new ApolloServer({ ...serverConfig })
@@ -95,7 +112,10 @@ export async function createExpressServer(
     json(config.graphql.bodyParser),
     expressMiddleware(apolloServer, {
       context: async ({ req, res }) => {
-        return await context.withRequest(req, res)
+        const responseHeaders = new Headers()
+        const requestContext = await context.withHeaders(headersFromRequest(req), responseHeaders)
+        responses.set(responseHeaders, res)
+        return requestContext
       },
     })
   )

--- a/packages/core/src/lib/middleware.ts
+++ b/packages/core/src/lib/middleware.ts
@@ -4,6 +4,7 @@ import type express from 'express'
 import { pkgDir } from '../pkg-dir.ts'
 import type { KeystoneConfig, KeystoneContext } from '../types/index.ts'
 import type { NextServer } from '../next.ts'
+import { addHeadersToResponse, headersFromRequest } from './context/node-headers.ts'
 
 const adminErrorHTMLFilepath = path.join(pkgDir, 'static', 'admin-error.html')
 
@@ -30,13 +31,15 @@ export function createAdminUIMiddlewareWithNextApp(
     try {
       // do nothing if this is a public page
       const isPublicPage = publicPages.includes(path)
-      const context = await commonContext.withRequest(req, res)
+      const responseHeaders = new Headers()
+      const context = await commonContext.withHeaders(headersFromRequest(req), responseHeaders)
       const wasAccessAllowed = isPublicPage ? true : await isAccessAllowed(context)
       const shouldRedirect = await pageMiddleware?.({
         context,
         wasAccessAllowed,
         basePath,
       })
+      addHeadersToResponse(responseHeaders, res)
 
       if (shouldRedirect) {
         res.header('Cache-Control', 'no-cache, max-age=0')

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -60,13 +60,13 @@ type StatelessSessionsOptions = {
 }
 
 function getToken(req: NonNullable<KeystoneContext['req']>, cookieName: string) {
-  const authorization = req.headers.authorization ?? ''
+  const authorization = req.get('authorization') ?? ''
 
   if (authorization.startsWith('Bearer ')) {
     return authorization.slice('Bearer '.length)
   }
 
-  const cookies = cookie.parse(req.headers.cookie || '')
+  const cookies = cookie.parse(req.get('cookie') || '')
   return cookies[cookieName]
 }
 
@@ -100,7 +100,7 @@ export function statelessSessions<Session>({
     async end({ context }) {
       if (!context?.res) return
 
-      context.res.setHeader(
+      context.res.set(
         'Set-Cookie',
         cookie.serialize(cookieName, '', {
           maxAge: 0,
@@ -117,7 +117,7 @@ export function statelessSessions<Session>({
       if (!context?.res) return
 
       const sealedData = await Iron.seal(data, secret, { ...ironOptions, ttl: maxAge * 1000 })
-      context.res.setHeader(
+      context.res.set(
         'Set-Cookie',
         cookie.serialize(cookieName, sealedData, {
           maxAge,

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -1,4 +1,3 @@
-import type { IncomingMessage, ServerResponse } from 'http'
 import type { DocumentNode, ExecutionResult, GraphQLSchema } from 'graphql/index.js'
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core'
 import type { InitialisedList } from '../lib/core/initialise-lists.ts'
@@ -27,11 +26,11 @@ export type KeystoneContext<TypeInfo extends BaseKeystoneTypeInfo = BaseKeystone
     }
   ): Promise<T>
 
-  req?: IncomingMessage
-  res?: ServerResponse
+  req?: Headers
+  res?: Headers
   sessionStrategy?: SessionStrategy<TypeInfo['session'], TypeInfo>
   session?: TypeInfo['session']
-  withRequest: (req: IncomingMessage, res?: ServerResponse) => Promise<KeystoneContext<TypeInfo>>
+  withHeaders: (req: Headers, res?: Headers) => Promise<KeystoneContext<TypeInfo>>
   withSession: (session?: TypeInfo['session']) => KeystoneContext<TypeInfo>
 
   // privilege escalation

--- a/tests/api-tests/request-context.test.ts
+++ b/tests/api-tests/request-context.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from 'vitest'
+import supertest from 'supertest'
+import { list } from '@keystone-6/core'
+import { allowAll } from '@keystone-6/core/access'
+import { text } from '@keystone-6/core/fields'
+import { setupTestRunner } from './test-runner.ts'
+
+const runner = setupTestRunner({
+  serve: true,
+  config: {
+    lists: {
+      User: list({ access: allowAll, fields: { name: text() } }),
+    },
+    session: {
+      async get({ context }) {
+        context.res?.set('x-request-authorization', context.req?.get('authorization') ?? '')
+        context.res?.set('x-request-forwarded-for', context.req?.get('x-forwarded-for') ?? '')
+        context.res?.append('set-cookie', 'first=1')
+        context.res?.append('set-cookie', 'second=2')
+        return { authorization: context.req?.get('authorization') }
+      },
+      async start() {},
+      async end() {},
+    },
+    server: {
+      extendExpressApp(app) {
+        app.use((req, _res, next) => {
+          req.headers['x-forwarded-for'] = req.socket.remoteAddress
+          next()
+        })
+      },
+    },
+  },
+})
+
+test(
+  'adapts request and response headers at the Express boundary',
+  runner(async ({ express }) => {
+    const response = await supertest(express)
+      .post('/api/graphql')
+      .set('authorization', 'Bearer token')
+      .set('x-forwarded-for', 'spoofed')
+      .send({ query: '{ __typename }' })
+      .expect(200)
+
+    expect(response.headers['x-request-authorization']).toBe('Bearer token')
+    expect(response.headers['x-request-forwarded-for']).toBeTruthy()
+    expect(response.headers['x-request-forwarded-for']).not.toBe('spoofed')
+    expect(response.headers['set-cookie']).toEqual(['first=1', 'second=2'])
+  })
+)
+
+test(
+  'creates request contexts from Headers',
+  runner(async ({ context }) => {
+    const requestHeaders = new Headers({ authorization: 'original' })
+    const responseHeaders = new Headers()
+    const requestContext = await context.withHeaders(requestHeaders, responseHeaders)
+
+    requestHeaders.set('authorization', 'changed')
+
+    expect(requestContext.req).not.toBe(requestHeaders)
+    expect(requestContext.req?.get('authorization')).toBe('original')
+    expect(requestContext.res).toBe(responseHeaders)
+    expect(requestContext.session).toEqual({ authorization: 'original' })
+
+    for (const derived of [
+      requestContext.sudo(),
+      requestContext.internal(),
+      requestContext.withSession({ authorization: 'replacement' }),
+    ]) {
+      expect(derived.req).toBe(requestContext.req)
+      expect(derived.res).toBe(responseHeaders)
+    }
+
+    const transactionContext = await requestContext.transaction(async transaction => transaction)
+    expect(transactionContext.req).toBe(requestContext.req)
+    expect(transactionContext.res).toBe(responseHeaders)
+  })
+)


### PR DESCRIPTION
This makes essentially the following change to `KeystoneContext`:

```diff
-req?: IncomingMessage
-res?: ServerResponse
+req?: Headers
+res?: Headers
```

This allows using Keystone's sessions in environments like Cloudflare Workers that don't use Node `IncomingMessage` and `ServerResponse`.

To provide these values, `withRequest` has also been replaced with `withHeaders` which takes the request and response headers.

Note: **Do not merge** until we're ready to do the next major